### PR TITLE
Feature/refactor init template

### DIFF
--- a/core/coreAppLogic.go
+++ b/core/coreAppLogic.go
@@ -94,7 +94,7 @@ func (ct *TextCopy) InsertBoilerPlateCode(CreatedFilePaths []string) (bool, erro
 
 	boilerPlateNamesToPath := make(map[string]string)
 	targetToBoilerPlateMatches := make(map[string]string)
-	boilerPlateTargetDir := "../boilerPlateCode/"
+	boilerPlateTargetDir := "../core/boilerPlateCode/"
 
 	// CREATE A MAP OF TARGETFILES:TESTFILES
 


### PR DESCRIPTION
There was an issue related to the path of the boilerPlateCode not being found when the copy function was invoked.

this has been resolved to use the correct path from where the executable file is located.